### PR TITLE
Add Foundry CLI and Getting Started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Select the following permissions:
 - [x] Run, execute, and test LogScale queries
 - [ ] (optional) Generate mock data to test your app
 
-Deploy the app to Foundry:
+Deploy the app:
 
 ```shell
 foundry apps deploy

--- a/README.md
+++ b/README.md
@@ -18,13 +18,89 @@ This app provides a filtered dashboard for the existing Falcon console Detection
 
 You can use this app to configure automated and manual actions for specific tactics and techniques.
 
-## Basic information
+## Prerequisites
 
-### Dependencies
+* Foundry CLI (instructions below)
+* Go v1.21+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
+* YARN (needed if modifying the app's UI). See https://yarnpkg.com/getting-started for installation instructions.
 
-- Foundry CLI
-- Go v1.21+ (needed if modifying functions). See https://go.dev/learn/ for instructions to install.
-- YARN (needed if modifying UI). See https://yarnpkg.com/getting-started for instructions to install.
+### Install the Foundry CLI
+
+You can install the Foundry CLI with Scoop on Windows or Homebrew on Linux/macOS.
+
+**Windows**:
+
+Install [Scoop](https://scoop.sh/). Then, add the Foundry CLI bucket and install the Foundry CLI.
+
+```shell
+scoop bucket add foundry https://github.com/crowdstrike/scoop-foundry-cli.git
+scoop install foundry
+```
+
+Or, you can download the [latest Windows zip file](https://assets.foundry.crowdstrike.com/cli/latest/foundry_Windows_x86_64.zip), expand it, and add the install directory to your PATH environment variable.
+
+**Linux and macOS**:
+
+Install [Homebrew](https://docs.brew.sh/Installation). Then, add the Foundry CLI repository to the list of formulae that Homebrew uses and install the CLI:
+
+```shell
+brew tap crowdstrike/foundry-cli
+brew install foundry
+```
+
+Run `foundry version` to verify it's installed correctly.
+
+## Getting Started
+
+Clone this sample to your local system, or [download as a zip file](https://github.com/CrowdStrike/foundry-sample-scalable-rtr/archive/refs/heads/main.zip).
+
+```shell
+git clone https://github.com/CrowdStrike/foundry-sample-scalable-rtr
+cd foundry-sample-scalable-rtr
+```
+
+Log in to Foundry:
+
+```shell
+foundry login
+```
+
+Select the following permissions:
+
+- [x] Run RTR Scripts
+- [x] Run, execute, and test Workflows
+- [x] Run, execute, and test API integrations
+- [x] Run, execute, and test LogScale queries
+- [ ] (optional) Generate mock data to test your app
+
+Deploy the app to Foundry:
+
+```shell
+foundry apps deploy
+```
+
+> [!TIP]
+> If you get an error that the name already exists, change the name to something unique to your CID in `manifest.yml`.
+
+Once the deployment has finished, release the app using the three-dot menu on the right. Next, go to **Foundry** > **App catalog**, find your app, and install it.
+
+Go to **Custom apps**. You should see your app listed and be able to enter a job. After the job executes, you'll receive an email with the execution information.
+
+### Development
+
+In order to be able to see (and develop) your local page/extension you have to:
+
+1. Run `foundry ui run` in this directory.
+2. The pages/extensions you're developing must have been built (_suggestion:_ use watchers for hot module reload).
+
+With the following, you should be able to start and develop all the projects under `mitre`:
+
+1. Run `yarn`.
+2. Run `yarn start`, this will run **type-checks** and `build-watch` for every project.
+3. Concurrently, run `foundry ui run`.
+4. Now, you are ready to test your changes with local code (remember to turn on "development mode").
+
+## About this sample app
 
 ### Foundry capabilities used
 
@@ -37,7 +113,7 @@ You can use this app to configure automated and manual actions for specific tact
 
 - UI
   - HTML, CSS
-  - Typescript, Vue
+  - TypeScript, Vue
 
 ### Directory structure
 
@@ -46,52 +122,10 @@ You can use this app to configure automated and manual actions for specific tact
 - `ui/extensions/remediations`. Single Page Application which serves as the extension mounted in the Detections page of the Falcon console.
 - `shared/mitre-vue`. Utility code and components shared between the `ui/pages/chart-vue` and `ui/extensions/remediations`.
 
-## Development
-
-In order to be able to see (and develop) your local page/extension you just have to:
-
-1. Run `foundry ui run` in this directory
-2. The pages/extensions you're developing must have been built (_suggestion:_ use watchers for hot module reload).
-
-With the following, you should be able to start and develop all of the projects under `mitre`:
-
-1. Run `yarn`
-2. Run `yarn start`, this will run **type-checks** and `build-watch` for every project.
-3. Concurrently, run `foundry ui run`.
-4. now you are ready to test your changes with local code (remember to turn on "development mode"
-
-## Running, deploying and installing the app
-
-For detailed info about running, deploying and installing this app in your CID, see the Falcon Foundry product documentation:
-
-- Overview and setup
-    * US-1: [Before you begin](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-    * US-2: [Before you begin](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-    * EU-1: [Before you begin](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-- Deploy an app
-  - US-1: [Deploy an app](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-  - US-2: [Deploy an app](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-  - EU-1: [Deploy an app](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-- Create a new app using this app as template
-  - US-1: [Create an app from a template](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-  - US-2: [Create an app from a template](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-  - EU-1: [Create an app from a template](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-- Run this app in development mode after deployment
-  - US-1: [Iterate in development mode](https://falcon.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-  - US-2: [Iterate in development mode](https://falcon.us-2.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-  - EU-1: [Iterate in development mode](https://falcon.eu-1.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-- Work with the Foundry capabilities of this app
-  - US-1: [App capabilities](https://falcon.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
-  - US-2: [App capabilities](https://falcon.us-2.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
-  - EU-1: [App capabilities](https://falcon.eu-1.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
-
 ## Foundry resources
 
-See our product documentation:
-
-- US-1: [Falcon Foundry](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
-- US-2: [Falcon Foundry](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
-- EU-1: [Falcon Foundry](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
+- Foundry documentation: [US-1](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
+- Foundry learning resources: [US-1](https://falcon.crowdstrike.com/foundry/learn) | [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn) | [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ You can use this app to configure automated and manual actions for specific tact
 
 ## Prerequisites
 
-* Foundry CLI (instructions below)
+* The Foundry CLI (instructions below).
 * Go v1.21+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
-* YARN (needed if modifying the app's UI). See https://yarnpkg.com/getting-started for installation instructions.
+* Yarn (needed if modifying the app's UI). See https://yarnpkg.com/getting-started for installation instructions.
 
 ### Install the Foundry CLI
 
@@ -52,11 +52,11 @@ Run `foundry version` to verify it's installed correctly.
 
 ## Getting Started
 
-Clone this sample to your local system, or [download as a zip file](https://github.com/CrowdStrike/foundry-sample-scalable-rtr/archive/refs/heads/main.zip).
+Clone this sample to your local system, or [download as a zip file](https://github.com/CrowdStrike/foundry-sample-mitre/archive/refs/heads/main.zip).
 
 ```shell
-git clone https://github.com/CrowdStrike/foundry-sample-scalable-rtr
-cd foundry-sample-scalable-rtr
+git clone https://github.com/CrowdStrike/foundry-sample-mitre
+cd foundry-sample-mitre
 ```
 
 Log in to Foundry:

--- a/README.md
+++ b/README.md
@@ -82,9 +82,18 @@ foundry apps deploy
 > [!TIP]
 > If you get an error that the name already exists, change the name to something unique to your CID in `manifest.yml`.
 
-Once the deployment has finished, release the app using the three-dot menu on the right. Next, go to **Foundry** > **App catalog**, find your app, and install it.
+Once the deployment has finished, you can release the app:
 
-Go to **Custom apps**. You should see your app listed and be able to enter a job. After the job executes, you'll receive an email with the execution information.
+```shell
+foundry apps release
+```
+
+Next, go to **Foundry** > **App catalog**, find your app, and install it. Select the **Open App** button in the success dialog. 
+
+> [!TIP]
+> If the app doesn't load, reload the page.
+
+You'll see the different types of [MITRE ATT&CK](https://attack.mitre.org/)s and see the detections associated with them.
 
 ### Development
 


### PR DESCRIPTION
This README is a bit different from the other two samples. It has a "Development" section that I moved into the Getting Started section.