### PR TITLE
Add sub-directories with package.json to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       - "/shared/mitre-vue"
       - "/ui/extensions/remediations"
       - "/ui/pages/chart-vue"
+    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/shared/mitre-vue"
+      - "/ui/extensions/remediations"
+      - "/ui/pages/chart-vue"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot was not checking other package.json files for updates. This PR fixes that. For example, running `npx npm-check-updates` in `shared/mitre-vue` shows the following:

```
 @crowdstrike/foundry-js         0.17.0  →   0.17.1
 @intlify/unplugin-vue-i18n      ^1.2.0  →   ^6.0.3
 @rushstack/eslint-patch        ^1.10.4  →  ^1.10.5
 @shoelace-style/shoelace        ^2.8.0  →  ^2.20.0
 @types/jsdom                   ^21.1.1  →  ^21.1.7
 @types/lodash.defaultsdeep      ^4.6.7  →   ^4.6.9
 @types/lodash.get               ^4.4.7  →   ^4.4.9
 @vue/eslint-config-prettier      7.1.0  →   10.2.0
 @vue/eslint-config-typescript  ^11.0.3  →  ^14.4.0
 @vue/tsconfig                   ^0.6.0  →   ^0.7.0
 eslint                          8.35.0  →   9.21.0
 eslint-config-prettier           9.0.0  →   10.0.2
 eslint-plugin-prettier          ^5.2.1  →   ^5.2.3
 eslint-plugin-vue              ^9.11.0  →  ^9.32.0
 jsdom                          ^22.1.0  →  ^26.0.0
 pinia                           ^2.1.3  →   ^3.0.1
 prettier                        ^3.0.0  →   ^3.5.3
 vite                            ^6.0.3  →   ^6.2.0
 vitest                         ^0.32.0  →   ^3.0.7
 vue-i18n                       ^10.0.4  →  ^11.1.1
 vue-tsc                         ^1.6.5  →   ^2.2.8
```