### PR TITLE
Improve dependabot to only scan the root directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/shared/mitre-vue"
-      - "/ui/extensions/remediations"
-      - "/ui/pages/chart-vue"
+    directory: "/"
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I thought it was necessary to specify each directory with a `package.json` in it, so I created https://github.com/CrowdStrike/foundry-sample-mitre/pull/65. 

However, after looking at it for a few days, I believe the `workspaces` element in the root `package.json` makes it so dependabot scans the other files too. 

Proof:

- https://github.com/CrowdStrike/foundry-sample-mitre/pull/111 updates all `package.json` files
- https://github.com/CrowdStrike/foundry-sample-mitre/pull/113 only updates `/shared/mitre-vue/package.json`

Therefore, I propose we move back to just scanning the root directory.
