### PR TITLE
Add quiet mode configuration for cleaner CI output

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,7 +125,7 @@ jobs:
           directory: e2e
 
       - name: Run Playwright tests
-        run: npx dotenvx run -- npx playwright test
+        run: npx dotenvx run --quiet -- npx playwright test
         working-directory: e2e
         env:
           CI: true

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 import { AuthFile } from './constants/AuthFile';
 
 if (!process.env.CI) {
-  require("dotenv").config({ path: ".env" });
+  require("dotenv").config({ path: ".env", quiet: true });
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
Adds quiet mode configuration to reduce noise in CI logs while maintaining full E2E test functionality.

## Changes Made
- **playwright.config.ts**: Added `quiet: true` to dotenv config to suppress missing .env file warnings during local development
- **.github/workflows/e2e.yml**: Added `--quiet` flag to dotenvx run command to minimize dotenvx output in CI

## Motivation
This aligns foundry-sample-mitre with the foundry-tutorial-quickstart implementation, providing consistent quiet behavior across both sample projects. The changes reduce log noise while preserving all functionality.

## Testing
- [x] E2E tests continue to pass with quiet configuration
- [x] CI logs show reduced noise while maintaining essential output
- [x] Local development remains unaffected

Matches implementation from [foundry-tutorial-quickstart PR #12](https://github.com/CrowdStrike/foundry-tutorial-quickstart/pull/12/commits/afce3a573c634e561ae2d88be38c2d1c7d658c32).