### PR TITLE
Fix E2E test concurrency issues

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: e2e-tests-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
Multiple PRs created simultaneously (especially Dependabot batch updates) cause E2E test failures due to:

1. **Deployment Collisions**: All PRs generate identical app names with minute-precision timestamps
2. **UI Confusion**: Multiple similar apps clutter the Falcon Custom Apps menu  
3. **Test Flakiness**: E2E tests can't reliably identify which app instance to test

## Solution
Add GitHub concurrency group to serialize E2E test execution:

- Only one E2E test runs at a time per repository
- Clean single-app environment for reliable testing  
- No deployment name collisions
- Predictable UI state for test automation

## Testing Plan
After merge, this will automatically queue concurrent E2E runs from the existing batch of Dependabot PRs, demonstrating the fix in action.

## Impact
- ✅ Eliminates E2E test failures from concurrent deployments
- ✅ Creates clean testing environment with single app
- ✅ Maintains test isolation and reliability
- ⏱️ Tests run sequentially (slower but reliable)