### PR TITLE
Fix rebuild workflow and implement conditional e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.actor != 'dependabot[bot]'
     env:
       FOUNDRY_API_CLIENT_ID: ${{ secrets.FOUNDRY_API_CLIENT_ID }}
       FOUNDRY_API_CLIENT_SECRET: ${{ secrets.FOUNDRY_API_CLIENT_SECRET }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,15 +14,15 @@ jobs:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2.4.0
-      - name: Auto-approve Dependabot PRs
-        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Auto-approve Dependabot PRs
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           commit-message: 'Rebuild with latest dependencies'
           title: 'Rebuild with latest dependencies'
           body: Weekly build with latest dependencies.


### PR DESCRIPTION
- Update `rebuild.yml`to use `PAT_TOKEN` instead of `GITHUB_TOKEN` (fixes stuck PRs by allowing rebuild PRs to trigger CI workflows)
- Add conditional logic to `e2e.yml` to skip Dependabot PRs 
- Reorder `merge.yml` steps for better auto-merge reliability 

These changes ensure:
- Rebuild PRs trigger full CI including e2e tests
- Dependabot PRs skip e2e but still run build/test jobs
- Faster Dependabot auto-merging with proper step sequencing