### PR TITLE
Fix CVEs: add resolutions for picomatch, brace-expansion, yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,14 +76,19 @@
   "resolutions": {
     "ajv": "6.14.0",
     "axios": "1.13.6",
+    "brace-expansion": "5.0.5",
     "diff": "8.0.3",
     "flatted": "3.4.2",
     "js-yaml": "4.1.1",
     "lodash": "4.17.23",
     "minimatch": "10.2.4",
+    "picomatch@npm:^2.3.1": "2.3.2",
+    "picomatch@npm:^4.0.2": "4.0.4",
+    "picomatch@npm:^4.0.3": "4.0.4",
     "rollup": "4.59.0",
     "tar": "7.5.11",
-    "tmp": "0.2.4"
+    "tmp": "0.2.4",
+    "yaml": "2.8.3"
   },
   "engines": {
     "node": ">=22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,12 +2507,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
+"brace-expansion@npm:5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
+  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
   languageName: node
   linkType: hard
 
@@ -5719,17 +5719,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.3.1":
+"picomatch@npm:2.3.2":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+"picomatch@npm:4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
@@ -7593,12 +7593,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.2.2, yaml@npm:^2.6.0":
-  version: 2.8.2
-  resolution: "yaml@npm:2.8.2"
+"yaml@npm:2.8.3":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
   bin:
     yaml: bin.mjs
-  checksum: 10c0/703e4dc1e34b324aa66876d63618dcacb9ed49f7e7fe9b70f1e703645be8d640f68ab84f12b86df8ac960bac37acf5513e115de7c970940617ce0343c8c9cd96
+  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds yarn resolutions to pin vulnerable transitive dependencies to patched versions:

- **picomatch** 4.0.3 -> 4.0.4 (ReDoS vulnerability). The 2.x line was already at the safe 2.3.2.
- **brace-expansion** 5.0.4 -> 5.0.5 (DoS vulnerability)
- **yaml** 2.8.2 -> 2.8.3 (stack overflow vulnerability)

All 35 existing tests pass. No breaking changes since these are patch-level updates within their respective major version lines.

Note: lodash 4.17.23 remains the latest available version and still has known CVEs with no upstream fix.