### PR TITLE
Fix CVE: upgrade vite to 7.3.2

### DIFF
--- a/shared/mitre-vue/package.json
+++ b/shared/mitre-vue/package.json
@@ -62,7 +62,7 @@
     "prettier": "3.6.2",
     "sinon": "21.0.0",
     "typescript": "5.9.2",
-    "vite": "7.3.1",
+    "vite": "7.3.2",
     "vitest": "3.2.4",
     "vue-tsc": "3.0.7"
   },

--- a/ui/extensions/remediations/package.json
+++ b/ui/extensions/remediations/package.json
@@ -46,7 +46,7 @@
     "prettier": "3.6.2",
     "sinon": "21.0.0",
     "typescript": "5.9.2",
-    "vite": "7.3.1",
+    "vite": "7.3.2",
     "vitest": "3.2.4",
     "vue-tsc": "3.0.7"
   },

--- a/ui/pages/chart-vue/package.json
+++ b/ui/pages/chart-vue/package.json
@@ -53,7 +53,7 @@
     "prettier": "3.6.2",
     "sinon": "21.0.0",
     "typescript": "5.9.2",
-    "vite": "7.3.1",
+    "vite": "7.3.2",
     "vitest": "3.2.4",
     "vue-tsc": "3.0.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,7 +963,7 @@ __metadata:
     prettier: "npm:3.6.2"
     sinon: "npm:21.0.0"
     typescript: "npm:5.9.2"
-    vite: "npm:7.3.1"
+    vite: "npm:7.3.2"
     vitest: "npm:3.2.4"
     vue: "npm:3.5.21"
     vue-i18n: "npm:11.2.8"
@@ -1003,7 +1003,7 @@ __metadata:
     prettier: "npm:3.6.2"
     sinon: "npm:21.0.0"
     typescript: "npm:5.9.2"
-    vite: "npm:7.3.1"
+    vite: "npm:7.3.2"
     vitest: "npm:3.2.4"
     vue: "npm:3.5.21"
     vue-i18n: "npm:11.2.8"
@@ -1043,7 +1043,7 @@ __metadata:
     prettier: "npm:3.6.2"
     sinon: "npm:21.0.0"
     typescript: "npm:5.9.2"
-    vite: "npm:7.3.1"
+    vite: "npm:7.3.2"
     vitest: "npm:3.2.4"
     vue: "npm:3.5.21"
     vue-i18n: "npm:11.2.8"
@@ -7081,7 +7081,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:7.3.1, vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
+"vite@npm:7.3.2":
+  version: 7.3.2
+  resolution: "vite@npm:7.3.2"
+  dependencies:
+    esbuild: "npm:^0.27.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/74be36907e208916f18bfec81c8eba18b869f0a170f1ece0a4dcb14874d0f0e7c022fb6c2ad896e3ee6c973fe88f53ac23b4078879ada340d8b263260868b8d4
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
   version: 7.3.1
   resolution: "vite@npm:7.3.1"
   dependencies:


### PR DESCRIPTION
Upgrades vite from 7.3.1 to 7.3.2 across all three UI packages (remediations, chart-vue, mitre-vue), fixing SSRF and XSS vulnerabilities. Dist unchanged (same content hashes). Tests pass.